### PR TITLE
index: set up page encoding explicitly

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,9 @@
 
 <html>
   <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
+
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 


### PR DESCRIPTION
The page has some issue rendering unicode when running under python http.server, this seems to fix it.